### PR TITLE
Add argument completion for `:ColorSwatchGenerate`

### DIFF
--- a/autoload/colorswatch.vim
+++ b/autoload/colorswatch.vim
@@ -17,6 +17,21 @@ function! colorswatch#generate(...) abort
 endfunction
 
 
+function! colorswatch#generate_complete(arglead, cmdline, cursorpos) abort
+	let args = split(substitute(a:cmdline[: a:cursorpos - len(a:arglead) - 1],
+				\ '\C^.\{-}C\%[olorSwatchGenerate]!\?', '', ''))
+	let n = len(args)
+	if n == 0
+		let candidates = ['all', 'original', 'cterm']
+	elseif n == 1
+		let candidates = ['default', 'minimal', 'csv', 'css', 'json']
+	else
+		let candidates = []
+	endif
+	return join(candidates, "\n")
+endfunction
+
+
 function! colorswatch#source(source_name) abort
 	try
 		let func_name = printf('colorswatch#source#%s#collect',

--- a/plugin/colorswatch.vim
+++ b/plugin/colorswatch.vim
@@ -7,7 +7,9 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-command! -nargs=* ColorSwatchGenerate call colorswatch#generate(<f-args>)
+command! -nargs=*
+			\ -complete=custom,colorswatch#generate_complete
+			\ ColorSwatchGenerate call colorswatch#generate(<f-args>)
 
 let g:loaded_colorswatch = 1
 


### PR DESCRIPTION
Hi,

I added support for argument completion for the `:ColorSwatchGenerate` command.

- 1st argument

    ```
    :ColorSwatchGenerate <C-a>
    ```
    
    ```
    :ColorSwatchGenerate all original cterm
                         ^----------------^
    ```

- 2nd argument

    ```
    :ColorSwatchGenerate all <C-a>
    ```
    
    ```
    :ColorSwatchGenerate all default minimal csv css json
                             ^--------------------------^
    ```

I believe this could be helpful for those who don't know/remember what can be an argument.
Please feel free to let me know if any improvements can be made.

Thanks!